### PR TITLE
[SFY-19608] - Removes product ID from push interaction and User Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,12 @@ For other integrations you can check [Master Integration](https://www.segmentify
 
 Segmentify Android SDK is available under the BSD-2 license.
 Please check LICENSE file to learn more about details.
+
+
+## Push Permission & User Updates 1.0.1
+1.0.1 update changes user events in the background. This is a completely internal and will not effect sdk users. Also productId parameter has been removed from push interaction event.
+
+Good Luck!
+
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.12.0'
+        classpath 'com.android.tools.build:gradle:8.13.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.1'
+        classpath 'com.android.tools.build:gradle:8.12.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/SegmentifyManager.kt
+++ b/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/SegmentifyManager.kt
@@ -644,7 +644,7 @@ object SegmentifyManager {
         userModel.eventName = Constant.userOperationEventName
         userModel.userOperationStep = Constant.registerStep
 
-        if (userModel.email == null && userModel.username == null) {
+        if (userModel.email == null) {
             SegmentifyLogger.printErrorLog("You must fill email or email before accessing sendUserLogout event")
             return
         }
@@ -657,7 +657,7 @@ object SegmentifyManager {
         var userModel = UserModel()
         userModel.eventName = Constant.userOperationEventName
         userModel.userOperationStep = Constant.registerStep
-        userModel.username = username
+        userModel.externalId = username
         userModel.fullName = fullName
         userModel.email = email
         userModel.mobilePhone = mobilePhone
@@ -672,11 +672,6 @@ object SegmentifyManager {
         userModel.eventName = Constant.userOperationEventName
         userModel.userOperationStep = Constant.signInStep
 
-        if (userModel?.username.isNullOrBlank()) {
-            SegmentifyLogger.printErrorLog("You must fill username before accessing change user event")
-            return
-        }
-
         if (userModel?.email.isNullOrBlank()) {
             SegmentifyLogger.printErrorLog("You must fill email before accessing change user event")
             return
@@ -689,7 +684,7 @@ object SegmentifyManager {
         var userModel = UserModel()
         userModel.eventName = Constant.userOperationEventName
         userModel.userOperationStep = Constant.signInStep
-        userModel.username = username
+        userModel.externalId = username
         userModel.email = email
 
         EventController.sendUserOperation(userModel)
@@ -699,7 +694,7 @@ object SegmentifyManager {
         var userModel = UserModel()
         userModel.eventName = Constant.userOperationEventName
         userModel.userOperationStep = Constant.logoutStep
-        userModel.username = username
+        userModel.externalId = username
         userModel.email = email
 
         EventController.sendUserOperation(userModel)
@@ -709,14 +704,10 @@ object SegmentifyManager {
         userModel.eventName = Constant.userOperationEventName
         userModel.userOperationStep = Constant.updateUserStep
 
-        if (userModel.email.isNullOrBlank() || userModel.username.isNullOrBlank()) {
+        if (userModel.email.isNullOrBlank()) {
             SegmentifyLogger.printErrorLog("You must fill username or email before accessing sendUserUpdate event")
             return
         }
-
-        //Email ve userName kaydedebilmek için
-        //clientPreferences.setUserName(userModel.username.toString())
-        //clientPreferences?.setEmail(userModel.email.toString())
 
         EventController.sendUserOperation(userModel)
     }
@@ -725,7 +716,7 @@ object SegmentifyManager {
         var userModel = UserModel()
         userModel.eventName = Constant.userOperationEventName
         userModel.userOperationStep = Constant.updateUserStep
-        userModel.username = username
+        userModel.externalId = username
         userModel.fullName = fullName
         userModel.email = email
         userModel.mobilePhone = mobilePhone
@@ -779,13 +770,12 @@ object SegmentifyManager {
         }
 
         if (notificationModel.type == NotificationType.CLICK) {
-            if (notificationModel.instanceId.isNullOrEmpty() && notificationModel.productId.isNullOrEmpty()) {
+            if (notificationModel.instanceId.isNullOrEmpty()) {
                 SegmentifyLogger.printErrorLog("You must fill deviceToken before accessing notification click event")
                 return
             } else {
                 clientPreferences?.setPushCampaignId(notificationModel.instanceId!!)
-                clientPreferences?.setPushCampaignProductId(notificationModel.productId!!)
-                sendClickView(notificationModel.instanceId!!, notificationModel.productId!!);
+                sendClickView(notificationModel.instanceId!!, notificationModel.instanceId!!);
             }
         }
         PushController.sendNotificationInteraction(notificationModel)

--- a/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/model/NotificationModel.kt
+++ b/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/model/NotificationModel.kt
@@ -1,22 +1,13 @@
 package com.segmentify.segmentifyandroidsdk.model
 
-import android.content.Context
-import android.net.Uri
 import android.os.Build
-import com.google.gson.annotations.SerializedName
 import com.segmentify.segmentifyandroidsdk.SegmentifyManager
-import com.segmentify.segmentifyandroidsdk.utils.ClientPreferences
 
 class NotificationModel{
 
     var deviceToken:String? = null
     var type:NotificationType? = null
     var instanceId:String? = null
-    var productId:String? = null
-    var topic:String? = null
-    var params:Map<String,String>? = null
-    private var email:String? = null
-    private  var userName:String? = null
     private  var userId : String?=null
     private  var osVersion:String?=null
     private  var os:String?=null
@@ -24,17 +15,19 @@ class NotificationModel{
 
 
     init {
+        if(type != NotificationType.PERMISSION_INFO){
+            deviceToken = null
+        }
 
-        if(type != NotificationType.PERMISSION_INFO){deviceToken = null }
         osVersion = Build.VERSION.SDK_INT.toString()
         os = "ANDROID"
         providerType = "FIREBASE"
+
         var userId_ = SegmentifyManager.clientPreferences?.getUserId()
-        var email_ = SegmentifyManager.clientPreferences?.getString("EMAIL")
-        var userName_ = SegmentifyManager.clientPreferences?.getString("USER_NAME")
-        if(!email_.isNullOrEmpty()){  email = email_  }
-        if(!userName_.isNullOrEmpty()){ userName = userName_}
-        if(!userId_.isNullOrEmpty()){ userId = userId_}
+
+        if(!userId_.isNullOrEmpty()){
+            userId = userId_
+        }
 
     }
 

--- a/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/model/UserModel.kt
+++ b/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/model/UserModel.kt
@@ -3,7 +3,7 @@ package com.segmentify.segmentifyandroidsdk.model
 import com.google.gson.annotations.SerializedName
 
 class UserModel : SegmentifyObject() {
-        var username:String? = null
+        var externalId:String? = null
         var email:String? = null
         var age:String? = null
         var birthDate:String? = null


### PR DESCRIPTION
Removes the productId property from the NotificationModel and updates the sendNotification click event to no longer require or utilize it.
Also renames username to externalId in UserModel.

The main reason for this change is to simplify the push notification interaction process by removing a redundant parameter. This makes the implementation cleaner and less prone to errors due to unnecessary data.

I Tried to not change user model behalf of it I added externalId as a new type to userModel & replaced username parameter with externalId in the event processes.

[ISSUED TASK](https://segmentify.atlassian.net/browse/SFY-19608)