### PR TITLE
[SFY-22447] Customer Data Platform Events - User Traits

### DIFF
--- a/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/SegmentifyManager.kt
+++ b/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/SegmentifyManager.kt
@@ -53,6 +53,8 @@ object SegmentifyManager {
         this.configModel.apiKey = apiKey
         this.configModel.dataCenterUrl = dataCenterUrl
         this.configModel.subDomain = subDomain
+        this.configModel.os = "ANDROID"
+        this.configModel.device = "ANDROID"
         setBaseApiUrl()
         ConnectionManager.rebuildServices()
     }
@@ -77,6 +79,8 @@ object SegmentifyManager {
         this.configModel.apiKey = appKey
         this.configModel.dataCenterUrl = dataCenterUrl
         this.configModel.subDomain = subDomain
+        this.configModel.os = "ANDROID"
+        this.configModel.device = "ANDROID"
         setBaseApiUrl()
 
         if (clientPreferences?.getSessionId().isNullOrBlank()) {
@@ -638,6 +642,16 @@ object SegmentifyManager {
         interactionModel.type = Constant.searchStep
 
         EventController.sendInteractionEvent(interactionModel)
+    }
+
+    fun sendUserTraits(properties: Map<String, Any?>) {
+        if (properties.isEmpty()) return
+
+        val model = UserTraitsEventModel().apply {
+            eventName = Constant.userTraitsEventName
+            this.properties = properties.filterValues { it != null }
+        }
+        EventController.sendUserTraits(model)
     }
 
     fun sendUserRegister(userModel: UserModel) {

--- a/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/controller/EventController.kt
+++ b/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/controller/EventController.kt
@@ -184,6 +184,21 @@ internal object EventController {
         }
     }
 
+    fun sendUserTraits(userTraitsEventModel: UserTraitsEventModel) {
+
+        if (!userTraitsEventModel.userId.isNullOrEmpty() && !userTraitsEventModel.sessionId.isNullOrEmpty()) {
+
+            ConnectionManager.getEventFactory().sendUserTraits(userTraitsEventModel, SegmentifyManager.configModel.apiKey!!)
+                    .enqueue(object : NetworkCallback<Any>() {
+                        override fun onSuccess(response: Any) {
+                        }
+                    })
+        } else {
+            SegmentifyLogger.printErrorLog("You must fill userid&sessionid before accessing user traits event")
+            return
+        }
+    }
+
     fun sendChangeUser(userChangeModel: UserChangeModel,segmentifyCallback : SegmentifyCallback<Boolean>){
 
         if(!userChangeModel.userId.isNullOrEmpty() && !userChangeModel.sessionId.isNullOrEmpty()){

--- a/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/model/ConfigModel.kt
+++ b/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/model/ConfigModel.kt
@@ -5,4 +5,7 @@ class ConfigModel {
     var dataCenterUrl:String? = null
     var dataCenterUrlPush:String? = null
     var subDomain:String? = null
+
+    var device:String = "ANDROID"
+    var os:String = "ANDROID"
 }

--- a/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/model/UserTraitsEventModel.kt
+++ b/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/model/UserTraitsEventModel.kt
@@ -1,0 +1,5 @@
+package com.segmentify.segmentifyandroidsdk.model
+
+class UserTraitsEventModel : SegmentifyObject() {
+    var properties: Map<String, Any?>? = null
+}

--- a/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/network/Factories/EventFactory.kt
+++ b/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/network/Factories/EventFactory.kt
@@ -34,6 +34,9 @@ interface EventFactory {
         @POST("/add/events/v1.json")
         fun sendUserOperation(@Body userModel: UserModel,@Query("apiKey") apiKey : String): Call<Any>
 
+        @POST("/add/events/v1.json")
+        fun sendUserTraits(@Body userTraitsEventModel: UserTraitsEventModel, @Query("apiKey") apiKey: String): Call<Any>
+
         //POST UserModel Object with steps as defined in documentation
         @POST("/add/events/v1.json")
         fun sendChangeUser(@Body userChangeModel: UserChangeModel,@Query("apiKey") apiKey : String): Call<Any>

--- a/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/utils/Constant.kt
+++ b/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/utils/Constant.kt
@@ -21,7 +21,7 @@ class Constant {
         val bannerGroupViewEventName = "BANNER_GROUP_VIEW"
         val internalBannerGroupEventName = "INTERNAL_BANNER_GROUP"
         val searchViewEventName = "SEARCH"
-        val userTraitsEventName = "user:traits"
+        val userTraitsEventName = "USER_TRAITS"
 
         //Steps
         val customerInformationStep = "customer"

--- a/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/utils/Constant.kt
+++ b/segmentifyandroidsdk/src/main/java/com/segmentify/segmentifyandroidsdk/utils/Constant.kt
@@ -21,6 +21,7 @@ class Constant {
         val bannerGroupViewEventName = "BANNER_GROUP_VIEW"
         val internalBannerGroupEventName = "INTERNAL_BANNER_GROUP"
         val searchViewEventName = "SEARCH"
+        val userTraitsEventName = "user:traits"
 
         //Steps
         val customerInformationStep = "customer"


### PR DESCRIPTION
Summary
iOS SDK’ya user:traits event desteği eklendi. Uygulamalar kullanıcı özelliklerini (traits) Segmentify’e gönderebilir; traits verisi yalnızca bu event’te payload’a yazılır ve diğer event’lerde temizlenerek yanlışlıkla taşınması engellenir.

JIRA: https://segmentify.atlassian.net/browse/SFY-22447

Changes
UserTraitsModel — properties: [String: Any] ile traits modeli (SegmentifyObject tabanlı)
SegmentifyManager.sendUserTraits — İki overload:
sendUserTraits(segmentifyObject: UserTraitsModel)
sendUserTraits(properties: [String: Any]) (boş dictionary gönderilmez)
SegmentifyRegisterRequest — userTraitsProperties alanı; eventName == "user:traits" iken payload’da properties key’i
Traits temizleme — user:traits dışındaki tüm event’lerde userTraitsProperties sıfırlanır (clearUserTraitsPropertiesForNonTraitsEvents, toDictionary, clearData)
Usage
// Model ile
let traits = UserTraitsModel(properties: [
    "plan": "premium",
    "loyaltyTier": "gold"
])
SegmentifyManager.sharedInstance().sendUserTraits(segmentifyObject: traits)
// Dictionary ile
SegmentifyManager.sharedInstance().sendUserTraits(properties: [
    "plan": "premium",
    "loyaltyTier": "gold"
])
Gönderilen event örneği:


{
  "eventName": "user:traits",
  "properties": {
    "plan": "premium",
    "loyaltyTier": "gold"
  }
}